### PR TITLE
add option to set status to 'madvise'

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ Mode of sysconfig thp. Must be in four digit octal notation.
 
 thp_status
 ----------
-Kernel configuration option to enable or disable Transparent Huge Pages by setting a value in /sys/kernel/mm/transparent_hugepage/enabled.  Valid values are 'always' or 'never'
+Kernel configuration option to enable or disable Transparent Huge Pages by setting a value in /sys/kernel/mm/transparent_hugepage/enabled.  Valid values are 'always,' 'never,' or 'madvise.'
 
 - *Default*: 'always'
 
 thp_defrag_status
 ----------
-Kernel configuration option to enable or disable Transparent Huge Pages Defragmentation by setting a value in /sys/kernel/mm/transparent_hugepage/defrag.  Valid values are 'always' or 'never'
+Kernel configuration option to enable or disable Transparent Huge Pages Defragmentation by setting a value in /sys/kernel/mm/transparent_hugepage/defrag.  Valid values are 'always,' 'never,' or 'madvise.'
 
 - *Default*: 'always'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,8 +44,8 @@ class thp (
     validate_bool($service_enable_real)
 
     # make sure our thp configuration options are valid.
-    validate_re($thp_status, '^(always)|(never)$', 'thp::thp_status is invalid and does not match the regex.')
-    validate_re($thp_defrag_status, '^(always)|(never)$', 'thp::thp_status is invalid and does not match the regex.')
+    validate_re($thp_status, '^(always)|(never)|(madvise)$', 'thp::thp_status is invalid and does not match the regex.')
+    validate_re($thp_defrag_status, '^(always)|(never)|(madvise)$', 'thp::thp_status is invalid and does not match the regex.')
 
 
     case $::osfamily {


### PR DESCRIPTION
As described here (http://techoverflow.net/blog/2013/08/01/how-to-check-if-hugepages-are-enabled-in-linux/) and elsewhere, another valid option for managing transparent huge pages is "madvise." This change adds a validation and updates the readme, so it should be pretty safe.
